### PR TITLE
Bring into 2021

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [xsc]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: DeLaGuardo/clojure-lint-action@master
+        with:
+          clj-kondo-args: --lint src test
+          check-name: clj-kondo
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: install-dependencies
+        run: lein deps
+      - name: run-tests
+        run: lein ci
+      - name: upload-code-coverage-report
+        uses: codecov/codecov-action@v1
+        with:
+          file: target/coverage/codecov.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2015-2016 Yannick Scherer
+Copyright (c) 2015-2021 Yannick Scherer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Contributions are always welcome. Just make sure the tests are passing.
 ## License
 
 ```
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2015-2016 Yannick Scherer
+Copyright (c) 2015-2021 Yannick Scherer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,40 +1,30 @@
 # pem-reader
 
+[![Clojars Artifact](https://img.shields.io/clojars/v/into-docker/pem-reader.svg)](https://clojars.org/into-docker/pem-reader)
+![CI](https://github.com/into-docker/pem-reader/workflows/CI/badge.svg?branch=master)
+[![codecov](https://codecov.io/gh/into-docker/pem-reader/branch/master/graph/badge.svg?token=GLSK1G95TX)](https://codecov.io/gh/into-docker/pem-reader)
+
 A lightweight library to read keys from PEM files.
 
 ## Usage
 
-__Leiningen__ ([via Clojars](https://clojars.org/xsc/pem-reader))
-
-[![Clojars Project](http://clojars.org/xsc/pem-reader/latest-version.svg)](http://clojars.org/xsc/pem-reader)
-
-__REPL__
-
 ```clojure
 (require '[pem-reader.core :as pem])
 
-(def pem (pem/read "test/keys/rsa-private-key.pem"))
-;; => #object[pem_reader.core.PEM 0x32c56ed9 "pem_reader.core.PEM@32c56ed9"]
-
-(pem/type pem)
-;; => :rsa-private-key
-
-(pem/as-bytes pem)
-;; => #object["[B" 0x5698633e "[B@5698633e"]
-
-(pem/private-key pem)
-;; => #object[sun.security.rsa.RSAPrivateCrtKeyImpl 0x9a2de04 "sun.security.rsa.RSAPrivateCrtKeyImpl@4940"]
-
-(pem/public-key pem)
-;; => nil
+(pem/read "test/keys/rsa-private-key.pem")
+;; => {:type :pkcs1,
+;;     :public-key #object[sun.security.rsa.RSAPublicKeyImpl ...],
+;;     :private-key #object[sun.security.rsa.RSAPrivateCrtKeyImpl ...]}
 ```
 
 ## Supported Formats
 
-- PKCS#1 (`RSA PRIVATE KEY`)
-- PKCS#8 (`PRIVATE KEY`)
-- X509 Public Key (`PUBLIC KEY`)
-- X509 Certificate (`CERTIFICATE`)
+| Format           | `:type`             | Result Keys                   |
+| ---------------- | ------------------- | ----------------------------- |
+| PKCS#1           | `:pkcs1`            | `:private-key`, `:public-key` |
+| PKCS#8           | `:pkcs8`            | `:private-key`                |
+| X509 Public Key  | `:x509-public-key`  | `:public-key`                 |
+| X509 Certificate | `:x509-certificate` | `:certificate`                |
 
 ## Rationale
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/project.clj
+++ b/project.clj
@@ -8,4 +8,19 @@
             :comment "MIT License"}
   :dependencies [[org.clojure/clojure "1.10.2" :scope "provided"]
                  [org.clojure/data.codec "0.1.1"]]
+  :profiles {:dev
+             {:global-vars {*warn-on-reflection* true}}
+             :kaocha
+             {:dependencies [[lambdaisland/kaocha "1.0.732"
+                              :exclusions [org.clojure/spec.alpha]]
+                             [lambdaisland/kaocha-cloverage "1.0.75"]]}
+             :ci
+             [:kaocha
+              {:global-vars {*warn-on-reflection* false}}]}
+  :aliases {"kaocha"    ["with-profile" "+kaocha" "run" "-m" "kaocha.runner"]
+            "ci"        ["with-profile" "+ci" "run" "-m" "kaocha.runner"
+                         "--reporter" "documentation"
+                         "--plugin"   "cloverage"
+                         "--codecov"
+                         "--no-cov-html"]}
   :pedantic? :abort)

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,11 @@
-(defproject xsc/pem-reader "0.1.2-SNAPSHOT"
-  :description "A lightweight reader, retrieving keys from PEM files."
+(defproject into-docker/pem-reader "1.0.0-SNAPSHOT"
+  :description "A lightweight reader for key/certificate files"
   :url "https://github.com/xsc/pem-reader"
-  :license {:name "MIT License"
-            :url "http://opensource.org/licenses/MIT"
+  :license {:name "MIT"
+            :url "https://choosealicense.com/licenses/mit"
             :year 2015
-            :key "mit"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/data.codec "0.1.0"]]
+            :key "mit"
+            :comment "MIT License"}
+  :dependencies [[org.clojure/clojure "1.10.2" :scope "provided"]
+                 [org.clojure/data.codec "0.1.1"]]
   :pedantic? :abort)

--- a/src/pem_reader/core.clj
+++ b/src/pem_reader/core.clj
@@ -1,124 +1,45 @@
 (ns pem-reader.core
-  (:refer-clojure :exclude [read type])
-  (:require [pem-reader.readers.pkcs1 :refer [read-pkcs1-spec]]
-            [clojure.java.io :as io]
-            [clojure.data.codec.base64 :as b64]
-            [clojure.string :as string])
-  (:import [java.security KeyFactory]
-           [java.security.spec
+  (:refer-clojure :exclude [read])
+  (:require [pem-reader.readers
+             [pkcs1 :refer [read-pkcs1-spec]]]
+            [pem-reader
+             [parse :refer [parse-pem]]
+             [rsa :as rsa]]
+            [clojure.java.io :as io])
+  (:import [java.security.spec
             PKCS8EncodedKeySpec
             X509EncodedKeySpec]
-           [javax.security.cert
-            X509Certificate]))
+           [java.security.cert
+            CertificateFactory]))
 
-;; ## Protocol + Implementation
+;; ## Readers
 
-(defprotocol ReadablePEM
-  "Protocol for a read PEM file."
-  (type [_]
-    "Keyword identifying the key type, generated from the PEM's `BEGIN` block,
-     e.g. `:rsa-private-key` for `RSA PRIVATE KEY`.")
-  (private-key [_]
-    "Get the key as an instance of `java.security.PrivateKey`.")
-  (public-key [_]
-    "Get the key as an instance of `java.security.PublicKey`."))
+(defn- gen-x509-certificate
+  [bytes]
+  (with-open [in (io/input-stream bytes)]
+    (let [factory (CertificateFactory/getInstance "X.509")]
+      {:type        :x509-certificate
+       :certificate (.generateCertificate factory in)})))
 
-(defprotocol ByteConvert
-  (as-bytes [_]))
+(defn- gen-x509-public-key
+  [bytes]
+  (let [spec (X509EncodedKeySpec. bytes)]
+    {:type       :x509-public-key
+     :public-key (rsa/as-public-key spec)}))
 
-(deftype PEM [type private-key public-key]
-  ReadablePEM
-  (type [_]
-    type)
-  (private-key [_]
-    private-key)
-  (public-key [_]
-    public-key)
+(defn- gen-pkcs8
+  [bytes]
+  (let [spec (PKCS8EncodedKeySpec. bytes)]
+    {:type        :pkcs8
+     :private-key (rsa/as-private-key spec)}))
 
-  ByteConvert
-  (as-bytes [_]
-    (.getEncoded (or private-key public-key))))
+(defn- gen-pkcs1
+  [bytes]
+  (let [{:keys [private public]} (read-pkcs1-spec bytes)]
+    {:type        :pkcs1
+     :public-key  (rsa/as-public-key public)
+     :private-key (rsa/as-private-key private)}))
 
-(extend-protocol ByteConvert
-  java.security.PrivateKey
-  (as-bytes [k]
-    (.getEncoded k))
-
-  java.security.PublicKey
-  (as-bytes [k]
-    (.getEncoded k)))
-
-;; ## Helpers
-
-(def ^:private +pem-pattern+
-  #"^\s*-{5}BEGIN (.+)-{5}\s+([a-zA-Z0-9-_/+\s=]+)\s+-{5}END (.+)-{5}\s*$")
-
-(defmacro ^:private spec->key-data
-  "Generate the key byte array from a KeySpec using the given algorithm and
-   lookup method."
-  [algorithm spec which]
-  `(let [spec# ~spec
-         kf# (KeyFactory/getInstance ~algorithm)
-         which# ~which]
-     {:private-key (if (which# :private) (.generatePrivate kf# spec#))
-      :public-key  (if (which# :public) (.generatePublic kf# spec#))}))
-
-(defn- rsa-key
-  "Generate an RSA private key from the given KeySpec."
-  [spec which]
-  (spec->key-data "RSA" spec which))
-
-;; ## Reader Logic
-
-(defn- read-type
-  "Keywordize the PEM/key type."
-  [v]
-  (-> v
-      (string/lower-case)
-      (string/replace #"[\s_]+" "-")
-      (keyword)))
-
-(defn- read-key-bytes
-  "Read the Base64 encoded key byte array."
-  [^String private-key]
-  (-> private-key
-      (string/replace #"\s+" "")
-      (.getBytes "UTF-8")
-      (b64/decode)))
-
-(defmulti read-key
-  "Read key from byte array. `type` is the lowercased, keywordized value
-   of the PEM's `BEGIN` block, e.g. `:rsa-private-key` for `RSA PRIVATE KEY`."
-  (fn [type bytes] type))
-
-(defmethod read-key :private-key
-  [_ bytes]
-  (rsa-key
-    (PKCS8EncodedKeySpec. bytes)
-    #{:private}))
-
-(defmethod read-key :rsa-private-key
-  [_ bytes]
-  (rsa-key
-    (read-pkcs1-spec bytes)
-    #{:private}))
-
-(defmethod read-key :certificate
-  [_ bytes]
-  (let [crt (X509Certificate/getInstance bytes)]
-    {:public-key (.getPublicKey crt)}))
-
-(defmethod read-key :public-key
-  [_ bytes]
-  (rsa-key
-    (X509EncodedKeySpec. bytes)
-    #{:public}))
-
-(defmethod read-key :default
-  [type _]
-  (throw
-    (IllegalArgumentException.
-      (format "cannot read PEMs of type '%s'" (str type)))))
 
 ;; ## Read Function
 
@@ -131,16 +52,17 @@
    - X509 Public Key (`PUBLIC KEY`)
    - X509 Certificate (`CERTIFICATE`)
 
-   The result will implement the `pem-reader.core/ReadablePEM` protocol."
+   The result will be a map with `:type` being one of `:pkcs1`, `:pkcs8`,
+   `:x509-public-key` or `:x509-certificate` and additional, type-specific
+   data."
   [file]
   (with-open [in (io/input-stream file)]
-    (let [data (slurp in :encoding "UTF-8")]
-      (when-let [[_ begin private-key end] (re-find +pem-pattern+ data)]
-        (assert (= begin end) "BEGIN and END block do not match.")
-        (let [key-bytes (read-key-bytes private-key)
-              key-type  (read-type begin)
-              key-data       (read-key key-type key-bytes)]
-          (->PEM
-            key-type
-            (:private-key key-data)
-            (:public-key key-data)))))))
+    (let [{:keys [type bytes]} (parse-pem in)]
+      (case type
+        :rsa-private-key (gen-pkcs1 bytes)
+        :private-key     (gen-pkcs8 bytes)
+        :certificate     (gen-x509-certificate bytes)
+        :public-key      (gen-x509-public-key bytes)
+        (throw
+          (IllegalArgumentException.
+            (format "cannot read PEMs of type '%s'" type)))))))

--- a/src/pem_reader/core.clj
+++ b/src/pem_reader/core.clj
@@ -65,4 +65,4 @@
         :public-key      (gen-x509-public-key bytes)
         (throw
           (IllegalArgumentException.
-            (format "cannot read PEMs of type '%s'" type)))))))
+            (format "Cannot read PEMs of type '%s'" type)))))))

--- a/src/pem_reader/parse.clj
+++ b/src/pem_reader/parse.clj
@@ -1,0 +1,38 @@
+(ns pem-reader.parse
+  (:require [clojure.string :as string]
+            [clojure.data.codec.base64 :as b64]))
+
+;; ## Pattern for PEM files
+
+(def ^:private +pem-pattern+
+  #"^\s*-{5}BEGIN (.+)-{5}\s+([a-zA-Z0-9-_/+\s=]+)\s+-{5}END (.+)-{5}\s*$")
+
+;; ## Helpers
+
+(defn- read-type
+  "Keywordize the PEM/key type."
+  [v]
+  (-> v
+      (string/lower-case)
+      (string/replace #"[\s_]+" "-")
+      (keyword)))
+
+(defn- decode-base64
+  "Read the Base64 encoded key byte array."
+  [^String base64-data]
+  (-> base64-data
+      (string/replace #"\s+" "")
+      (.getBytes "UTF-8")
+      (b64/decode)))
+
+;; ## Parse
+
+(defn parse-pem
+  "Parse PEM file, creating a map of `:type` (content type) and `:bytes`
+  (decoded content as byte array)."
+  [in]
+  (let [data (slurp in :encoding "UTF-8")]
+    (when-let [[_ begin base64-data end] (re-find +pem-pattern+ data)]
+      (assert (= begin end) "BEGIN and END block do not match.")
+      {:type   (read-type begin)
+       :bytes  (decode-base64 base64-data)})))

--- a/src/pem_reader/parse.clj
+++ b/src/pem_reader/parse.clj
@@ -32,7 +32,10 @@
   (decoded content as byte array)."
   [in]
   (let [data (slurp in :encoding "UTF-8")]
-    (when-let [[_ begin base64-data end] (re-find +pem-pattern+ data)]
-      (assert (= begin end) "BEGIN and END block do not match.")
-      {:type   (read-type begin)
-       :bytes  (decode-base64 base64-data)})))
+    (or (when-let [[_ begin base64-data end] (re-find +pem-pattern+ data)]
+          (assert (= begin end) "BEGIN and END block do not match.")
+          {:type   (read-type begin)
+           :bytes  (decode-base64 base64-data)})
+        (throw
+         (IllegalArgumentException.
+           "Not in PEM format!")))))

--- a/src/pem_reader/readers/pkcs1.clj
+++ b/src/pem_reader/readers/pkcs1.clj
@@ -1,6 +1,8 @@
 (ns pem-reader.readers.pkcs1
   (:require [clojure.string :as string])
-  (:import [java.security.spec RSAPrivateCrtKeySpec]))
+  (:import (java.security.spec
+            RSAPrivateCrtKeySpec
+            RSAPublicKeySpec)))
 
 ;; ## Derivative
 ;;
@@ -71,7 +73,7 @@
                        :primitive)
         tag          (bit-and classifier-octet 0x1f)
         [type-k c?]  (expected-tags tag)
-        class-k      (expected-classes class)
+        _class-k      (expected-classes class)
         [length rst] (read-length rst)]
     (assert (= constructed? c?) "DER: primitive/constructed conflict.")
     {:type         type-k
@@ -103,4 +105,5 @@
   "Read a PKCS#1 encoded private key into a `RSAPrivateCrtKeySpec`."
   [bytes]
   (let [[_ m e d p q e1 e2 c] (read-key-sequence bytes)]
-    (RSAPrivateCrtKeySpec. m e d p q e1 e2 c)))
+    {:private (RSAPrivateCrtKeySpec. m e d p q e1 e2 c)
+     :public  (RSAPublicKeySpec. m e)}))

--- a/src/pem_reader/rsa.clj
+++ b/src/pem_reader/rsa.clj
@@ -1,0 +1,13 @@
+(ns ^:no-doc pem-reader.rsa
+  (:import (java.security KeyFactory)
+           (java.security.spec KeySpec)))
+
+(defn as-private-key
+  [^KeySpec spec]
+  (let [kf (KeyFactory/getInstance "RSA")]
+    (.generatePrivate kf spec)))
+
+(defn as-public-key
+  [^KeySpec spec]
+  (let [kf (KeyFactory/getInstance "RSA")]
+    (.generatePublic kf spec)))

--- a/test/pem_reader/core_test.clj
+++ b/test/pem_reader/core_test.clj
@@ -30,3 +30,14 @@
   (let [result (pem/read "test/keys/public-key.pem")]
     (is (= :x509-public-key (:type result)))
     (is (instance? PublicKey (:public-key result)))))
+
+(deftest t-invalid-format
+  (is (thrown-with-msg?
+       IllegalArgumentException
+       #"Not in PEM format!"
+       (pem/read "project.clj")))
+  (is (thrown-with-msg?
+       AssertionError
+       #"BEGIN and END block do not match"
+       (pem/read
+        (.getBytes "-----BEGIN X-----\nabcdef\n-----END Y-----")))))

--- a/test/pem_reader/core_test.clj
+++ b/test/pem_reader/core_test.clj
@@ -40,4 +40,9 @@
        AssertionError
        #"BEGIN and END block do not match"
        (pem/read
-        (.getBytes "-----BEGIN X-----\nabcdef\n-----END Y-----")))))
+        (.getBytes "-----BEGIN X-----\nabcdef\n-----END Y-----"))))
+  (is (thrown-with-msg?
+       IllegalArgumentException
+       #"Cannot read PEMs of type ':unknown'"
+       (pem/read
+        (.getBytes "-----BEGIN UNKNOWN-----\nabcdef\n-----END UNKNOWN-----")))))


### PR DESCRIPTION
Breaking changes within!

- Change artifact name to `into-docker/pem-reader`
- Move from `PEM` object to maps.
- Remove byte conversion sugar.
- Use Github Actions.
- Use Kaocha.